### PR TITLE
Make filesystems view in tree style

### DIFF
--- a/models/zfs.py
+++ b/models/zfs.py
@@ -83,6 +83,7 @@ class Filesystem(restful.Resource):
 			fs.append(
 				{
 					'name' : root_fs.name,
+					'type': 'Pool',
 					'available' : root_fs.properties['available'],
 					'referenced' : root_fs.properties['referenced'],
 					'used' : root_fs.properties['used'],
@@ -105,6 +106,7 @@ class Filesystem(restful.Resource):
 				fs.append(
 					{
 						'name' : sub_fs.name,
+						'type' : fs_type_to_str(sub_fs.type),
 						'available' : sub_fs.properties['available'],
 						'referenced' : sub_fs.properties['referenced'],
 						'used' : sub_fs.properties['used'],
@@ -191,3 +193,21 @@ def zpool_status_to_str(status):
 		return "Ok"
 	else:
 		return "Not Implemented."
+
+#TODO: Change to dict!
+def fs_type_to_str(type):
+	if type == zfs_type_t.ZFS_TYPE_FILESYSTEM:
+		return "Filesystem"
+	if type == zfs_type_t.ZFS_TYPE_SNAPSHOT:
+		return "Snapshot"
+	if type == zfs_type_t.ZFS_TYPE_VOLUME:
+		return "Volume"
+	if type == zfs_type_t.ZFS_TYPE_POOL:
+		return "Pool"
+	if type == zfs_type_t.ZFS_TYPE_BOOKMARK:
+		return "Bookmark"
+	else:
+		return "Unknown"
+
+# vim: ts=4 sw=4 sts=4 noet
+

--- a/static/tabs/filesystems.html
+++ b/static/tabs/filesystems.html
@@ -12,11 +12,21 @@
 			<th>Referenced:</th>
 			<th>Used:</th>
 		</tr>
-		<tr ng-repeat="fs in pool.fs | orderBy : 'name'">
-			<td>{{ fs.name }}</td>
-			<td>{{ fs.available | bytes }} </td>
-			<td>{{ fs.referenced | bytes }} </td>
-			<td>{{ fs.used | bytes }} </td>
-		</tr>
+		<tbody ng-repeat="fs in (fss = (pool.fs | orderBy: 'name'))">
+			<tr>
+				<td>{{ fs.type != 'Pool' ? (fss[$index + 1] != undefined ? '├' : '└') : '' }}<span class="fa" ng-class="{ 'fa-database': fs.type == 'Pool', 'fa-hdd-o': fs.type == 'Volume', 'fa-folder-open': fs.type == 'Filesystem' }"> {{ fs.name }}</span></td>
+				<td>{{ fs.available | bytes }} </td>
+				<td>{{ fs.referenced | bytes }} </td>
+				<td>{{ fs.used | bytes }} </td>
+			</tr>
+				<!-- TODO: What about bookmarks? -->
+				<tr ng-repeat="snap in fs.snaps">
+					<td>{{ fss[$index + 1] != undefined ? '│' : '' }} {{ fs.snaps[$index + 1] != undefined ? '├' : '└' }}<span class="fa fa-clock-o"> {{ snap.name }}</span></td>
+					<td>-</td>
+					<td>{{ snap.referenced | bytes }}</td>
+					<td>{{ snap.used | bytes }}</td>
+				</tr>
+			</tr>
+		</tbody>
 	</table>
 </div>


### PR DESCRIPTION
- Show each pool as tree
- Add icons for pools/filesystems/VDEVs
- Show snapshots

Screenshot:

![tree](https://cloud.githubusercontent.com/assets/4971975/12379758/9b20288a-bd60-11e5-8724-c56eec8b1d12.png)

I still have to visualize bookmarks.

@FireDrunk Also it would be nice to have all pools in the same tree, do you think this is a good idea?

@FireDrunk And should I hide the part before the name? So tank/windowsdata is just called windowsdata? It's redundant and I don't know if it's needed.
